### PR TITLE
Custom invalidation strategy

### DIFF
--- a/Haneke/Haneke.swift
+++ b/Haneke/Haneke.swift
@@ -53,3 +53,13 @@ func errorWithCode(_ code: Int, description: String) -> Error {
     let userInfo = [NSLocalizedDescriptionKey: description]
     return NSError(domain: HanekeGlobals.Domain, code: code, userInfo: userInfo) as Error
 }
+
+internal var defaultDiskCapacityStrategy = deleteItemsOverCapacity
+
+
+/// Set the module wide default disk cache invalidation strategy
+///
+/// - Parameter strategy: new disk cache invalidation strategy
+public func setDefaultDiskCapacityStrategy(_ strategy: @escaping (DiskCache, FileManager) -> Void) {
+    defaultDiskCapacityStrategy = strategy
+}

--- a/Haneke/Haneke.swift
+++ b/Haneke/Haneke.swift
@@ -12,7 +12,16 @@ public struct HanekeGlobals {
     
     public static let Domain = "io.haneke"
     
+    /// Set the module wide default disk cache invalidation strategy
+    ///
+    /// - Parameter strategy: new disk cache invalidation strategy
+    public static func setDefaultDiskCapacityStrategy(_ strategy: @escaping (DiskCache, FileManager) -> Void) {
+        defaultDiskCapacityStrategy = strategy
+    }
+    
 }
+
+internal var defaultDiskCapacityStrategy = deleteItemsOverCapacity
 
 public struct Shared {
     
@@ -52,14 +61,4 @@ public struct Shared {
 func errorWithCode(_ code: Int, description: String) -> Error {
     let userInfo = [NSLocalizedDescriptionKey: description]
     return NSError(domain: HanekeGlobals.Domain, code: code, userInfo: userInfo) as Error
-}
-
-internal var defaultDiskCapacityStrategy = deleteItemsOverCapacity
-
-
-/// Set the module wide default disk cache invalidation strategy
-///
-/// - Parameter strategy: new disk cache invalidation strategy
-public func setDefaultDiskCapacityStrategy(_ strategy: @escaping (DiskCache, FileManager) -> Void) {
-    defaultDiskCapacityStrategy = strategy
 }

--- a/Haneke/Haneke.swift
+++ b/Haneke/Haneke.swift
@@ -21,7 +21,7 @@ public struct HanekeGlobals {
     
 }
 
-internal var defaultDiskCapacityStrategy = deleteItemsOverCapacity
+internal var defaultDiskCapacityStrategy = DiskCache.Invalidation.deleteItemsOverCapacity
 
 public struct Shared {
     

--- a/HanekeDemo/AppDelegate.swift
+++ b/HanekeDemo/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 return
             }
             
-            DiskCache.Invalidation.deleteItemsCreatedBefore(invalidationDate)(diskCache, fileManager)
+            DiskCache.Invalidation.deleteItemsAddedBefore(invalidationDate)(diskCache, fileManager)
            
         }
         

--- a/HanekeDemo/AppDelegate.swift
+++ b/HanekeDemo/AppDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Haneke
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -15,8 +16,47 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        
+        setDefaultDiskCapacityStrategy { diskCache, fileManager in
+            deleteItemsOverCapacity(diskCache, fileManager)
+            
+            let cachePath = diskCache.path
+            
+            let calendar = Calendar.current
+            let targetDate = calendar.date(byAdding: .minute, value: -1, to: Date())!
+            
+            guard let paths = try? fileManager.directoryContents(at: URL(string: cachePath)!, before: targetDate)
+                .compactMap({ $0.path }), paths.count > 0 else {
+                return
+            }
+            
+            diskCache.removeFiles(for: paths)
+            print("\(paths.count) old files have been removed")
+            return
+        }
+        
         return true
     }
-
 }
 
+
+private extension FileManager {
+    func directoryContents(at url: URL) throws -> [URL] {
+        return try contentsOfDirectory(at: url,
+                                        includingPropertiesForKeys: nil,
+                                        options: [.skipsHiddenFiles])
+        
+    }
+    
+    func directoryContents(at url: URL, before date: Date) throws -> [URL] {
+        return try directoryContents(at: url).filter({ u in
+            let attributes = try attributesOfItem(atPath: u.path)
+            
+            guard let creationDate = attributes[.creationDate] as? Date else {
+                return true
+            }
+            
+            return creationDate < date
+        })
+    }
+}

--- a/HanekeDemo/AppDelegate.swift
+++ b/HanekeDemo/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         
-        setDefaultDiskCapacityStrategy { diskCache, fileManager in
+        Shared.setDefaultDiskCapacityStrategy { diskCache, fileManager in
             deleteItemsOverCapacity(diskCache, fileManager)
             
             let cachePath = diskCache.path


### PR DESCRIPTION
We need our cache to allow us to customize the way we invalidate objects in the cache. This achieves that.

# Testing
To test this out I have modified the default disk capacity strategy in the test apps AppDelegate.

currently ```invalidationDate = calendar.date(byAdding: .minute, value: -1, to: Date())```
will specifies that our target invalidation date is one minute in the past. 

to see this in action breakpoint in ```DiskCache.swift```  at ```diskCache.removeFiles(for: paths)```
around line 256.  wait a minute or so and restart the app. ```paths``` should be a non empty array.

other than this you may notice that after a minute the images take longer to appear... although this isn't always the case as these images are quite small, so the method above works for more accurate verificaton

## Note:  this is dependent on [#2](https://github.com/stockx/HanekeSwift/pull/3)